### PR TITLE
[B-004] feat: add Effect cancellation helpers and Store-managed cance…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Store Core Implementation (B-002)**
+- **Store Core Implementation**
   - `Store<State, Action>` class with @MainActor publishing
   - ObservableObject conformance for SwiftUI integration
   - Action dispatching with `send(_:)` method
@@ -24,20 +24,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Reducer<State, Action>` type alias for pure functions
   - Reducer utilities: `combine()`, `forAction()`, `transform()`
   - State mutation through `inout` parameters
+- **Cancellation Helpers**
+  - `Effect.cancellable(id:cancelInFlight:)` to identify and optionally cancel in-flight work
+  - `Effect.cancel(id:)` to explicitly cancel effects by identifier
+  - Store-managed in-flight task tracking keyed by cancellation ID
 - **Comprehensive Testing**
-  - 17 test cases covering all core functionality
+  - 20 test cases covering all core functionality
   - Store initialization and action handling tests
   - Effect execution and chaining tests
+  - Cancellation behavior tests (cancel-in-flight, metadata)
   - Reducer utility tests
   - Store scoping functionality tests
 - **Documentation & Examples**
   - Updated README with practical usage examples
+  - Added cancellation usage examples and guidance
   - Counter example showing basic TCA patterns
   - Effect example demonstrating async operations
   - SwiftUI integration examples
 
 ### Changed
 - Updated README to reflect new Store core functionality
+- Updated Effect and Store to support identifier-based cancellation
 - Enhanced TCAKit.swift with comprehensive usage documentation
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -120,6 +120,43 @@ let store = Store(
 )
 ```
 
+### Effect Cancellation
+
+You can mark effects as cancellable by an identifier and optionally cancel in-flight work.
+
+```swift
+enum AppAction {
+    case load
+    case cancelLoad
+    case loaded(String)
+}
+
+let store = Store(
+    initialState: AppState(),
+    reducer: { state, action in
+        switch action {
+        case .load:
+            return Effect<AppAction>
+                .task(
+                    operation: {
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        return "Result"
+                    },
+                    transform: AppAction.loaded
+                )
+                .cancellable(id: "load", cancelInFlight: true)
+
+        case .cancelLoad:
+            return .cancel(id: "load")
+
+        case .loaded(let value):
+            state.message = value
+            return .none
+        }
+    }
+)
+```
+
 ## Requirements
 
 - iOS 15.0+


### PR DESCRIPTION
### PR Summary

- feat: add Effect cancellation helpers and Store-managed cancellation (B-004)
- Added `Effect.cancellable(id:cancelInFlight:)` and `Effect.cancel(id:)`
- Store now tracks in-flight tasks by ID and cancels when requested
- Added tests for cancel-in-flight and cancellation metadata (total tests: 20)
- Updated README with a short cancellation usage example
- Updated CHANGELOG under Unreleased to reflect these changes
- No breaking changes; existing APIs unchanged and behavior preserved

Why: Enables safe, testable cancellation of async work, aligning with Swift concurrency and keeping APIs simple.